### PR TITLE
Added a tool to read .gro file and reorder the charges.

### DIFF
--- a/parse_gaussian_charges.py
+++ b/parse_gaussian_charges.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 
 """
-Script used to parse Gaussian09/16 partial charges determined via Mulliken, CHelp, CHelpG, HLY, MK or MKUFF to GROMACS topology file generated from LigParGen.
+Script used to parse Gaussian09/16 partial charges determined via Mulliken, CHelp, CHelpG, 
+HLY, MK or MKUFF to GROMACS topology file generated from LigParGen.
 
 Author: Rafael Bicudo Ribeiro
 Date: SET/2022
@@ -11,9 +12,15 @@ import os
 import sys
 import argparse
 
-def find_natoms(topfile):
+def find_natoms(topfile: str) -> int:
 	"""
 	Return the number of atoms in the molecule.
+
+	PARAMETERS:
+	topfile [type: str] -> topology (.itp) file
+
+	OUTPUT:
+	Number of atoms [type: int]
 	"""
 
 	with open(topfile, "r") as f:
@@ -32,9 +39,15 @@ def find_natoms(topfile):
 
 	return int(words[0])
 
-def check_top_order(topfile):
+def top_order(topfile: str) -> list:
 	"""
 	Return a vector with atoms types ordered by line.
+
+	PARAMETERS:
+	topfile [type: str] -> topology (.itp) file
+
+	OUTPUT:
+	Atom types [type: list[str]]
 	"""
 
 	with open(topfile, "r") as f:
@@ -57,9 +70,17 @@ def check_top_order(topfile):
 
 	return atoms_type
 
-def read_gaussian_charges(topfile, gaussianlogfile):
+def read_gaussian_charges(topfile: str, gaussianlogfile: str) -> list:
 	"""
 	Return a vector with Gaussian partial charges.
+
+	PARAMETERS:
+	topfile [type: str] -> topology (.itp) file
+	gaussianlogfile [type: str] -> Gaussian09/16 output file with partial charges
+
+	OUTPUT:
+	qm_charges [type: list[float]] -> List with partial charge 
+	gaussian_atoms [type: list[str]] -> List with the corresponding atoms
 	"""
 
 	natoms = find_natoms(topfile)
@@ -77,7 +98,7 @@ def read_gaussian_charges(topfile, gaussianlogfile):
 
 			if var_bool and i in range(natoms+2):
 				words = line.split()
-				i = i + 1
+				i += 1
 				if len(words) > 2:
 					qm_charges.append(round(float(words[2]), 4))
 					gaussian_atoms.append(words[1])
@@ -86,9 +107,17 @@ def read_gaussian_charges(topfile, gaussianlogfile):
 
 	return qm_charges, gaussian_atoms
 
-def read_mulliken_charges(topfile, gaussianlogfile):
+def read_mulliken_charges(topfile: str, gaussianlogfile: str) -> list:
 	"""
 	Return a vector with Gaussian partial charges determined via Mulliken population analysis.
+
+	PARAMETERS:
+	topfile [type: str] -> topology (.itp) file
+	gaussianlogfile [type: str] -> Gaussian09/16 output file with partial charges
+
+	OUTPUT:
+	qm_charges [type: list[float]] -> List with partial charge 
+	gaussian_atoms [type: list[str]] -> List with the corresponding atoms
 	"""
 
 	natoms = find_natoms(topfile)
@@ -106,7 +135,7 @@ def read_mulliken_charges(topfile, gaussianlogfile):
 
 			if var_bool and i in range(natoms+2):
 				words = line.split()
-				i = i + 1
+				i += 1
 				if len(words) > 2:
 					qm_charges.append(round(float(words[2]), 4))
 					gaussian_atoms.append(words[1])
@@ -115,9 +144,15 @@ def read_mulliken_charges(topfile, gaussianlogfile):
 
 	return qm_charges, gaussian_atoms
 
-def correct_total_charge(qm_charges):
+def correct_total_charge(qm_charges: list) -> list:
 	"""
 	Change the charge of the first atom to ensure quantum charges sum up to zero.
+
+	PARAMETERS:
+	qm_charges [type: list[float]] -> list with partial charges.
+
+	OUTPUT:
+	qm_charges [type: list[float]] -> list with corrected partial charge summing up to zero.
 	"""
 
 	sum = 0
@@ -133,9 +168,45 @@ def correct_total_charge(qm_charges):
 
 	return qm_charges
 
-def parse_charges(topfile, gaussianlogfile, method):
+def reorder_top_charges(qm_charges: list, grofile: str) -> list:
+	"""
+	Change the ordering of atoms to match with the .gro file.
+
+	PARAMETERS:
+	qm_charges [type: list[float]] -> list with partial charges.
+	grofile [type: str] -> .gro file where atomic ordering matchs the topology file.
+
+	OUTPUT:
+	qm_charges [type: list[float]] -> list with partial charges reordering according to the .gro file.
+	"""
+
+	qm_charges_reordered = [0] * len(qm_charges)
+
+	with open(grofile, "r") as f:
+		for i in range(3):
+			line = f.readline()
+		
+		for j in range(len(qm_charges)):
+			words = line.split()
+			qm_charges_reordered[j] = qm_charges[int(words[2])-1]
+			line = f.readline()
+
+	print("Charges were reordered using {} file.".format(grofile))
+
+	return qm_charges_reordered
+
+def parse_charges(topfile: str, gaussianlogfile: str, method: str, grofile: str):
 	"""
 	Write the new parsed_* file with quantum mechanical charges.
+
+	PARAMETERS:
+	topfile [type: str] -> topology (.itp) file
+	gaussianlogfile [type: str] -> Gaussian09/16 output file with partial charges
+	method [type: str] -> method used to determine the partial charges
+	grofile [type: str] -> .gro file where atomic ordering matchs the topology file.
+
+	OUTPUT:
+	A new "parsed_*.itp" file with charges updated.
 	"""
 
 	# Read the file and adjust the header accordingly
@@ -156,7 +227,7 @@ def parse_charges(topfile, gaussianlogfile, method):
 		fout.write(line)
 		line = f.readline()
 
-	# Use the appropriate function to collect QM charges from each method
+		# Use the appropriate function to collect QM charges from each method
 
 		ESP_methods = ['hly', 'chelpg', 'mk', 'chelp', 'mkuff', 'hlygat']
 		if method.lower() in ESP_methods:
@@ -167,21 +238,34 @@ def parse_charges(topfile, gaussianlogfile, method):
 			print('Charge population method not supported (try "python3 parse_gaussian_charges.py -h").')
 			sys.exit(0)
 
-	# Check if topology and gaussian output atoms are in the same order
+		# Check if topology and gaussian output atoms are in the same order
 
-		topology_atoms = check_top_order(topfile)
+		topology_atoms = top_order(topfile)
+
+		diff_order = False
 
 		for i in range(len(topology_atoms)):
 			if topology_atoms[i] != gaussian_atoms[i]:
-				print('Atoms in the topology file are ordered differently from the gaussian output file. \nAtom {}: {} (topology file) and {} (gaussian file). \nPlease order both files in the same way.'.format(i+1, topology_atoms[i], gaussian_atoms[i]))
-				sys.exit(0)
+				diff_order = True
+				if args.grofile:
+					break
+				else:
+					print("""Atoms in the topology file are ordered differently from the gaussian output file. 
+Atom {}: {} (topology file) and {} (gaussian file).\nPlease order both files in the same way or provide the \
+correctly ordered .gro file using the -g flag.""".format(i+1, topology_atoms[i], gaussian_atoms[i]))
+					sys.exit(0)
 
-	# Correct the total charge
+		# Correct the total charge
 
 		qm_charges = correct_total_charge(qm_charges)
 		i = 0
 
-	# Write the new .itp with QM charges
+		# If required, reorder the atomic charges according to the .gro file matching with .itp file
+
+		if args.grofile:
+			qm_charges = reorder_top_charges(qm_charges, grofile)
+
+		# Write the new .itp with QM charges
 
 		while ("opls" in line) or ("ppg" in line) or line.strip().startswith(";"):
 			if line.strip().startswith(";"):
@@ -190,7 +274,9 @@ def parse_charges(topfile, gaussianlogfile, method):
 				continue
 
 			words = line.split()
-			line = line.replace(words[6], str(qm_charges[i]))
+			# line = line.replace(words[6], str(qm_charges[i]))
+			line = '{:>6}{:>11}{:>7}{:>7}{:>7}{:>7}{:>11.4f}{:>11.4f}\n'.format(words[0], words[1], words[2], words[3],
+					words[4], words[5], qm_charges[i], float(words[7]))
 			fout.write(line)
 			line = f.readline()
 			i = i + 1
@@ -204,10 +290,11 @@ def parse_charges(topfile, gaussianlogfile, method):
 
 if __name__ == '__main__':
 	parser = argparse.ArgumentParser(description="Recieves a GROMACS topology generated from LigParGen and Gaussian output file to parse QM partial charges.")
-	parser.add_argument("topfile", help="the topology file (.top file) containing the molecule data for the OPLS-AA force field.")
-	parser.add_argument("gaussianlogfile", help="the gaussian log file with partial charges.")
-	parser.add_argument("--method", "-m", help="the method used to determine the charge populations (chelp, chelpg, mk, mkuff, hly or hlygat).")
+	parser.add_argument("topfile", type=str, help="the topology file (.top file) containing the molecule data for the OPLS-AA force field.")
+	parser.add_argument("gaussianlogfile", type=str, help="the gaussian log file with partial charges.")
+	parser.add_argument("--method", "-m", type=str, help="the method used to determine the charge populations (chelp, chelpg, mk, mkuff, hly or hlygat).")
+	parser.add_argument("--grofile", "-g", type=str, help="the .gro file with the same order as the topology file.")
 
 	args = parser.parse_args()
 
-	parse_charges(args.topfile, args.gaussianlogfile, args.method)
+	parse_charges(args.topfile, args.gaussianlogfile, args.method, args.grofile)


### PR DESCRIPTION
Since some topology generators (e.g. PolyParGen) change the order of atoms in the topology file from the .pdb/.xyz file, and the parse_gaussian_charges.py script reads data from the Gaussian output with the original ordering, I added a flag that enables one to provide an additional .gro file with the correct ordering. For example, one should add "-g reordered_*.gro" in the command line to read the .gro file with the proper ordering from reorder_ligpargen.py to ensure charges are correctly parsed.